### PR TITLE
Fix snapshot version check for downloading artificats

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -2,5 +2,5 @@
 echo "Downloading Jitsi Call App version ${JITSI_CALL_VERSION}"
 GROUP_ID=org.exoplatform
 ARTIFACT_ID=jitsi-call
-[[ ${JITSI_CALL_VERSION} =~ .*x-SNAPSHOT$ ]] && DOWNLOAD_URL="https://repository.exoplatform.org/service/local/artifact/maven/redirect?r=exo-addons-snapshots&g=${GROUP_ID}&a=${ARTIFACT_ID}&v=${JITSI_CALL_VERSION}" || DOWNLOAD_URL="https://repository.exoplatform.org/service/local/artifact/maven/redirect?r=exo-addons-releases&g=${GROUP_ID}&a=${ARTIFACT_ID}&v=${JITSI_CALL_VERSION}"
+[[ ${JITSI_CALL_VERSION} =~ .*-SNAPSHOT$ ]] && DOWNLOAD_URL="https://repository.exoplatform.org/service/local/artifact/maven/redirect?r=exo-addons-snapshots&g=${GROUP_ID}&a=${ARTIFACT_ID}&v=${JITSI_CALL_VERSION}" || DOWNLOAD_URL="https://repository.exoplatform.org/service/local/artifact/maven/redirect?r=exo-addons-releases&g=${GROUP_ID}&a=${ARTIFACT_ID}&v=${JITSI_CALL_VERSION}"
 wget -O /jitsi-call.jar ${DOWNLOAD_URL}


### PR DESCRIPTION
Before this fix, the snapshot version condition handles only standard version. with the add of new snapshot version, the condition is no more compatible.